### PR TITLE
Limit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This script automates the process of updating your Trellis installation to the l
   - User configurations
   - Host configurations
   - Trellis CLI configuration
-- Commits changes to your Git repository
+- Commits changes to your Git repository (commented out by default)
 
 ## Usage
 

--- a/trellis-updater.sh
+++ b/trellis-updater.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Set your project slug here
+# Set your project slug here like imagewize.com
 PROJECT="site.com"
 
 # Paths based on project
@@ -45,19 +45,19 @@ rsync -av \
   $TEMP_DIR/trellis/ $TRELLIS_DIR/
 
 # Step 7: Clean up temporary directory
-rm -rf $TEMP_DIR
+# rm -rf $TEMP_DIR
 
 # Step 8: Return to project directory
-cd $PROJECT_DIR
+# cd $PROJECT_DIR
 
 # Step 9: Check status of changes
-git status
+# git status
 
 # Step 10: Review diff of changes
-git diff trellis/
+# git diff trellis/
 
 # Step 11: Add changes if everything looks good
-git add trellis/
+# git add trellis/
 
 # Step 12: Commit the changes
-git commit -m "Update Trellis to latest version while preserving custom configurations"
+# git commit -m "Update Trellis to latest version while preserving custom configurations"


### PR DESCRIPTION
This pull request introduces minor updates to the `README.md` and `trellis-updater.sh` script to clarify usage instructions and comment out certain commands for safer execution. The changes aim to improve user understanding and prevent accidental actions during script execution.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R20): Clarified that committing changes to the Git repository is now commented out by default to prevent unintended commits.

### Script Updates:
* [`trellis-updater.sh`](diffhunk://#diff-ff55bd84716514edd478eb1cce68392e0a405889af39e68d22d8398f80b22112L3-R3): Updated the placeholder project slug with a more descriptive example (`imagewize.com`) to improve clarity for users.
* [`trellis-updater.sh`](diffhunk://#diff-ff55bd84716514edd478eb1cce68392e0a405889af39e68d22d8398f80b22112L48-R63): Commented out potentially destructive or unintended commands (`rm -rf $TEMP_DIR`, `cd $PROJECT_DIR`, `git status`, `git diff`, `git add`, and `git commit`) to ensure users manually review and execute these steps as needed.