### PR TITLE
Standard cp wo -a

### DIFF
--- a/trellis-updater.sh
+++ b/trellis-updater.sh
@@ -14,7 +14,7 @@ DIFF_DIR=~/trellis-diff
 mkdir -p $BACKUP_DIR
 
 # Step 2: Back up the entire current Trellis directory including hidden files
-cp -ra $TRELLIS_DIR/ $BACKUP_DIR/
+cp -r $TRELLIS_DIR/ $BACKUP_DIR/
 
 # Step 3: Clone fresh Trellis to temporary directory
 mkdir -p $TEMP_DIR


### PR DESCRIPTION
This pull request makes a minor change to the `trellis-updater.sh` script, specifically in the backup process. The `-a` flag was removed from the `cp` command, simplifying the command to only use the `-r` flag.

* [`trellis-updater.sh`](diffhunk://#diff-ff55bd84716514edd478eb1cce68392e0a405889af39e68d22d8398f80b22112L17-R17): Changed the `cp` command in the backup step to remove the `-a` flag, leaving only the `-r` flag for recursive copying.