### PR TITLE
Exclude .github

### DIFF
--- a/trellis-updater.sh
+++ b/trellis-updater.sh
@@ -33,6 +33,7 @@ rsync -av \
   --exclude=".vault_pass" \
   --exclude=".trellis/" \
   --exclude=".git/" \
+  --exclude=".github/" \
   --exclude="group_vars/all/vault.yml" \
   --exclude="group_vars/development/vault.yml" \
   --exclude="group_vars/production/vault.yml" \


### PR DESCRIPTION
This pull request updates the `trellis-updater.sh` script to enhance its functionality by excluding additional directories during the `rsync` operation.

Enhancements to the `rsync` operation:

* [`trellis-updater.sh`](diffhunk://#diff-ff55bd84716514edd478eb1cce68392e0a405889af39e68d22d8398f80b22112R36): Added `.github/` to the list of excluded directories in the `rsync` command to prevent unnecessary synchronization of GitHub-specific files.