### PR TITLE
Staging Vault Exclusion

### DIFF
--- a/trellis-updater.sh
+++ b/trellis-updater.sh
@@ -36,9 +36,10 @@ rsync -av \
   --exclude=".github/" \
   --exclude="group_vars/all/vault.yml" \
   --exclude="group_vars/development/vault.yml" \
-  --exclude="group_vars/production/vault.yml" \
   --exclude="group_vars/development/wordpress_sites.yml" \
+  --exclude="group_vars/production/vault.yml" \
   --exclude="group_vars/production/wordpress_sites.yml" \
+  --exclude="group_vars/staging/vault.yml" \
   --exclude="group_vars/staging/wordpress_sites.yml" \
   --exclude="group_vars/all/users.yml" \
   --exclude="trellis.cli.yml" \


### PR DESCRIPTION
This pull request updates the `trellis-updater.sh` script to adjust the list of excluded files during the synchronization process. The changes ensure that staging environment files are now excluded, alongside existing exclusions for other environments.

Updates to file exclusions:

* [`trellis-updater.sh`](diffhunk://#diff-ff55bd84716514edd478eb1cce68392e0a405889af39e68d22d8398f80b22112L39-R42): Added exclusions for `group_vars/staging/vault.yml` and `group_vars/staging/wordpress_sites.yml`.