### PR TITLE
README Exclusion List Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ This script automates the process of updating your Trellis installation to the l
   - User configurations
   - Host configurations
   - Trellis CLI configuration
-- Commits changes to your Git repository (commented out by default)
+- Commits changes to your Git repository
 
 ## Usage
 
 1. Edit the script to set your project slug:
 ```bash
-# Set your project slug here
+# Set your project slug here like imagewize.com
 PROJECT="your-site-name"
 ```
 
@@ -45,11 +45,13 @@ The script specifically preserves the following files/directories:
 - `.vault_pass`
 - `.trellis/`
 - `.git/`
+- `.github/`
 - `group_vars/all/vault.yml`
 - `group_vars/development/vault.yml`
-- `group_vars/production/vault.yml`
 - `group_vars/development/wordpress_sites.yml`
+- `group_vars/production/vault.yml`
 - `group_vars/production/wordpress_sites.yml`
+- `group_vars/staging/vault.yml`
 - `group_vars/staging/wordpress_sites.yml`
 - `group_vars/all/users.yml`
 - `trellis.cli.yml`


### PR DESCRIPTION
This pull request updates the `README.md` file to clarify instructions and expand the list of preserved files and directories. The changes improve the documentation for better usability and accuracy.

### Documentation Improvements:

* Clarified the example for setting the project slug in the script, providing a more specific example (`imagewize.com`) to guide users. (`README.md`, [README.mdL20-R26](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R26))
* Expanded the list of preserved files and directories to include `.github/` and `group_vars/staging/vault.yml`, ensuring these are explicitly mentioned as retained during updates. (`README.md`, [README.mdR48-R54](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R54))