### PR TITLE
Remove Deleted Files & Dirs

### DIFF
--- a/trellis-updater.sh
+++ b/trellis-updater.sh
@@ -29,7 +29,7 @@ diff -rq $TEMP_DIR/trellis/ $TRELLIS_DIR/ > $DIFF_DIR/changes.txt
 rm -rf $TEMP_DIR/trellis/.git
 
 # Step 6: Update Trellis files using rsync with explicit excludes
-rsync -av \
+rsync -av --delete \
   --exclude=".vault_pass" \
   --exclude=".trellis/" \
   --exclude=".git/" \


### PR DESCRIPTION
This pull request updates the `trellis-updater.sh` script to enhance the synchronization process by ensuring outdated files are removed during updates.

Key change:

* Modified the `rsync` command in `trellis-updater.sh` to include the `--delete` flag, ensuring that files in the destination directory that no longer exist in the source are removed during synchronization.